### PR TITLE
Update SnapshotSamples.kt

### DIFF
--- a/compose/runtime/runtime/samples/src/main/java/androidx/compose/runtime/samples/SnapshotSamples.kt
+++ b/compose/runtime/runtime/samples/src/main/java/androidx/compose/runtime/samples/SnapshotSamples.kt
@@ -45,7 +45,7 @@ fun snapshotFlowSample() {
     val collectionScope: CoroutineScope = TODO("Use your scope here")
 
     // Collect the flow and offer greetings!
-    collectionScope.launch { greetPersonFlow.collect { println(greeting) } }
+    collectionScope.launch { greetPersonFlow.collect { flowGreeting -> println(flowGreeting) } }
 
     // ...
 


### PR DESCRIPTION
The updated line changes the output from only posting `"Ahoy"` to `"Ahoy, Sean"`. The use of collect on `greetPersonFlow` is confusing in the context of only printing the `greeting` within the snapshot.

